### PR TITLE
Registry:v2.0 and verifier_electricity:v1.2

### DIFF
--- a/src/ProjectOrigin.Stamp.Server/ProjectOrigin.Stamp.Server.csproj
+++ b/src/ProjectOrigin.Stamp.Server/ProjectOrigin.Stamp.Server.csproj
@@ -49,13 +49,13 @@
 
   <ItemGroup>
     <Protobuf Include="../Protos/common.proto" Link="Protos\common.proto">
-      <SourceUrl>https://raw.githubusercontent.com/project-origin/registry/v1.3.1/src/Protos/common.proto</SourceUrl>
+      <SourceUrl>https://raw.githubusercontent.com/project-origin/registry/v2.0.0/protos/common.proto</SourceUrl>
     </Protobuf>
     <Protobuf Include="../Protos/registry.proto" Link="Protos\registry.proto">
-      <SourceUrl>https://raw.githubusercontent.com/project-origin/registry/v1.3.1/src/Protos/registry.proto</SourceUrl>
+      <SourceUrl>https://raw.githubusercontent.com/project-origin/registry/v2.0.0/protos/registry.proto</SourceUrl>
     </Protobuf>
     <Protobuf Include="../Protos/electricity.proto" Link="Protos\electricity.proto">
-      <SourceUrl>https://raw.githubusercontent.com/project-origin/registry/v1.3.1/src/Protos/electricity.proto</SourceUrl>
+      <SourceUrl>https://raw.githubusercontent.com/project-origin/verifier_electricity/v1.2.0/protos/electricity.proto</SourceUrl>
     </Protobuf>
   </ItemGroup>
 

--- a/src/ProjectOrigin.Stamp.Test/TestClassFixtures/RegistryFixture.cs
+++ b/src/ProjectOrigin.Stamp.Test/TestClassFixtures/RegistryFixture.cs
@@ -84,7 +84,7 @@ public class RegistryFixture : IAsyncLifetime
                 .WithEnvironment("Network__ConfigurationUri", configurationUri)
                 .WithWaitStrategy(
                     Wait.ForUnixContainer()
-                    .UntilMessageIsLogged("Application started")
+                    .UntilMessageIsLogged("Application started", o => o.WithTimeout(TimeSpan.FromMinutes(1)))
                 )
                 .Build();
 
@@ -116,8 +116,7 @@ public class RegistryFixture : IAsyncLifetime
             .WithEnvironment("ConnectionStrings__Database", registryPostgresContainer.GetConnectionString())
             .WithWaitStrategy(
                 Wait.ForUnixContainer()
-                    .UntilMessageIsLogged("Application started")
-            /* .UntilPortIsAvailable(GrpcPort) */
+                .UntilMessageIsLogged("Application started", o => o.WithTimeout(TimeSpan.FromMinutes(1)))
             )
             .Build()
         );

--- a/src/ProjectOrigin.Stamp.Test/TestClassFixtures/RegistryFixture.cs
+++ b/src/ProjectOrigin.Stamp.Test/TestClassFixtures/RegistryFixture.cs
@@ -84,7 +84,7 @@ public class RegistryFixture : IAsyncLifetime
                 .WithEnvironment("Network__ConfigurationUri", configurationUri)
                 .WithWaitStrategy(
                     Wait.ForUnixContainer()
-                    .UntilMessageIsLogged("Application started", o => o.WithTimeout(TimeSpan.FromSeconds(30)))
+                    .UntilMessageIsLogged("Application started")
                 )
                 .Build();
 
@@ -116,7 +116,7 @@ public class RegistryFixture : IAsyncLifetime
             .WithEnvironment("ConnectionStrings__Database", registryPostgresContainer.GetConnectionString())
             .WithWaitStrategy(
                 Wait.ForUnixContainer()
-                    .UntilMessageIsLogged("Application started", o => o.WithTimeout(TimeSpan.FromSeconds(30)))
+                    .UntilMessageIsLogged("Application started")
             /* .UntilPortIsAvailable(GrpcPort) */
             )
             .Build()

--- a/src/ProjectOrigin.Stamp.Test/TestClassFixtures/RegistryFixture.cs
+++ b/src/ProjectOrigin.Stamp.Test/TestClassFixtures/RegistryFixture.cs
@@ -1,10 +1,12 @@
 using System.Text;
 using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Configurations;
 using DotNet.Testcontainers.Containers;
 using DotNet.Testcontainers.Images;
 using DotNet.Testcontainers.Networks;
 using ProjectOrigin.HierarchicalDeterministicKeys;
 using ProjectOrigin.HierarchicalDeterministicKeys.Interfaces;
+using Testcontainers.PostgreSql;
 using Testcontainers.RabbitMq;
 using Xunit;
 
@@ -12,8 +14,8 @@ namespace ProjectOrigin.Stamp.Test.TestClassFixtures;
 
 public class RegistryFixture : IAsyncLifetime
 {
-    private const string registryImage = "ghcr.io/project-origin/registry-server:1.3.0";
-    private const string electricityVerifierImage = "ghcr.io/project-origin/electricity-server:1.1.0";
+    private const string registryImage = "ghcr.io/project-origin/registry-server:2.0.0";
+    private const string electricityVerifierImage = "ghcr.io/project-origin/electricity-server:1.2.0";
     protected const int GrpcPort = 5000;
     private const int RabbitMqHttpPort = 15672;
     private const string registryName = "TestRegistry";
@@ -21,17 +23,18 @@ public class RegistryFixture : IAsyncLifetime
     private const string VerifierAlias = "verifier-container";
     private const string RabbitMqAlias = "rabbitmq-container";
 
-    private readonly IContainer registryContainer;
+    private readonly Lazy<IContainer> registryContainer;
     private readonly IContainer verifierContainer;
     private readonly Testcontainers.RabbitMq.RabbitMqContainer rabbitMqContainer;
+    private readonly PostgreSqlContainer registryPostgresContainer;
     protected readonly INetwork Network;
     private readonly IFutureDockerImage rabbitMqImage;
 
     public const string RegistryName = registryName;
     public IPrivateKey Dk1IssuerKey { get; init; }
     public IPrivateKey Dk2IssuerKey { get; init; }
-    public string RegistryUrl => $"http://{registryContainer.Hostname}:{registryContainer.GetMappedPublicPort(GrpcPort)}";
-    protected string RegistryContainerUrl => $"http://{registryContainer.IpAddress}:{GrpcPort}";
+    public string RegistryUrl => $"http://{registryContainer.Value.Hostname}:{registryContainer.Value.GetMappedPublicPort(GrpcPort)}";
+    protected string RegistryContainerUrl => $"http://{registryContainer.Value.IpAddress}:{GrpcPort}";
 
     public RegistryFixture()
     {
@@ -54,22 +57,42 @@ public class RegistryFixture : IAsyncLifetime
         Dk1IssuerKey = Algorithms.Ed25519.GenerateNewPrivateKey();
         Dk2IssuerKey = Algorithms.Ed25519.GenerateNewPrivateKey();
 
+        var config = $"""
+        registries:
+          {registryName}:
+            url: http://{RegistryAlias}:{GrpcPort}
+        areas:
+          DK1:
+            issuerKeys:
+              - publicKey: "{Convert.ToBase64String(Encoding.UTF8.GetBytes(Dk1IssuerKey.PublicKey.ExportPkixText()))}"
+          DK2:
+            issuerKeys:
+              - publicKey: "{Convert.ToBase64String(Encoding.UTF8.GetBytes(Dk2IssuerKey.PublicKey.ExportPkixText()))}"
+        """;
+
+        var tempFilePath = Path.GetTempFileName() + ".yaml";
+        var configurationUri = "file:///app/tmp/" + Path.GetFileName(tempFilePath);
+        File.WriteAllText(tempFilePath, config);
+
         verifierContainer = new ContainerBuilder()
                 .WithImage(electricityVerifierImage)
                 .WithNetwork(Network)
                 .WithNetworkAliases(VerifierAlias)
+                .WithResourceMapping(tempFilePath, "/app/tmp/")
                 .WithPortBinding(GrpcPort, true)
                 .WithCommand("--serve")
-                .WithEnvironment("Issuers__DK1", Convert.ToBase64String(Encoding.UTF8.GetBytes(Dk1IssuerKey.PublicKey.ExportPkixText())))
-                .WithEnvironment("Issuers__DK2", Convert.ToBase64String(Encoding.UTF8.GetBytes(Dk2IssuerKey.PublicKey.ExportPkixText())))
-                .WithEnvironment($"Registries__{RegistryName}__Address", $"http://{RegistryAlias}:{GrpcPort}")
+                .WithEnvironment("Network__ConfigurationUri", configurationUri)
                 .WithWaitStrategy(
                     Wait.ForUnixContainer()
-                        .UntilPortIsAvailable(GrpcPort)
-                    )
+                    .UntilMessageIsLogged("Application started", o => o.WithTimeout(TimeSpan.FromSeconds(30)))
+                )
                 .Build();
 
-        registryContainer = new ContainerBuilder()
+        registryPostgresContainer = new PostgreSqlBuilder()
+            .WithImage("postgres:15")
+            .Build();
+
+        registryContainer = new Lazy<IContainer>(() => new ContainerBuilder()
             .WithImage(registryImage)
             .WithNetwork(Network)
             .WithNetworkAliases(RegistryAlias)
@@ -80,7 +103,6 @@ public class RegistryFixture : IAsyncLifetime
             .WithEnvironment("Verifiers__project_origin.electricity.v1", $"http://{VerifierAlias}:{GrpcPort}")
             .WithEnvironment("IMMUTABLELOG__TYPE", "log")
             .WithEnvironment("BlockFinalizer__Interval", "00:00:05")
-            .WithEnvironment("PERSISTANCE__TYPE", "in_memory")
             .WithEnvironment("cache__TYPE", "InMemory")
             .WithEnvironment("RabbitMq__Hostname", RabbitMqAlias)
             .WithEnvironment("RabbitMq__AmqpPort", RabbitMqBuilder.RabbitMqPort.ToString())
@@ -91,11 +113,14 @@ public class RegistryFixture : IAsyncLifetime
             .WithEnvironment("TransactionProcessor__Servers", "1")
             .WithEnvironment("TransactionProcessor__Threads", "5")
             .WithEnvironment("TransactionProcessor__Weight", "10")
+            .WithEnvironment("ConnectionStrings__Database", registryPostgresContainer.GetConnectionString())
             .WithWaitStrategy(
                 Wait.ForUnixContainer()
-                    .UntilPortIsAvailable(GrpcPort)
+                    .UntilMessageIsLogged("Application started", o => o.WithTimeout(TimeSpan.FromSeconds(30)))
+            /* .UntilPortIsAvailable(GrpcPort) */
             )
-            .Build();
+            .Build()
+        );
     }
 
     public virtual async Task InitializeAsync()
@@ -104,12 +129,14 @@ public class RegistryFixture : IAsyncLifetime
         await Network.CreateAsync();
         await rabbitMqContainer.StartAsync();
         await verifierContainer.StartAsync();
-        await registryContainer.StartAsync();
+        await registryPostgresContainer.StartAsync();
+        await registryContainer.Value.StartAsync();
     }
 
     public virtual async Task DisposeAsync()
     {
-        await registryContainer.StopAsync();
+        await registryContainer.Value.StopAsync();
+        await registryPostgresContainer.StopAsync();
         await rabbitMqContainer.StopAsync();
         await verifierContainer.StopAsync();
         await Network.DisposeAsync();

--- a/src/Protos/electricity.proto
+++ b/src/Protos/electricity.proto
@@ -48,6 +48,14 @@ message ClaimedEvent {
     project_origin.common.v1.Uuid allocation_id = 2;
 }
 
+message WithdrawnEvent {
+
+}
+
+message UnclaimedEvent {
+    project_origin.common.v1.Uuid allocation_id = 1;
+}
+
 enum GranularCertificateType {
     INVALID = 0;
     CONSUMPTION = 1;


### PR DESCRIPTION
# Upgrade to new versions of registry and verifier_electricity

After the upgrade of registry and verifier_electricity, I experienced some unexpected bugs.

I managed to make it "work on my computer", but then it seemed to fail on the build server.

This PR should not be merged in, it is meant as an inspiration for finding the correct solution:

Here are the changes: 
- I used WithResourceMapping to add a file to the test container (This was to solve permission errors)
- I had to change to a different "WaitStrategy", because the two test containers where suddenly "stalling" when waiting for the GRPC port? Very strange?. Instead, I use UntilMessageIsLogged("Application started") is logged, which worked locally but failed on the build server? Very weird again
- The registry seems to no longer support an in-memory database. I have added a PostgresContainer and wrapped the RegistryContainer in "Lazy<IContainer>", because the registry have a dependency on the PostgresContainer ConnectionString