### PR TITLE
Upgrade registry to v2.0 and verifier to v1.2

### DIFF
--- a/src/ProjectOrigin.Stamp.Server/ProjectOrigin.Stamp.Server.csproj
+++ b/src/ProjectOrigin.Stamp.Server/ProjectOrigin.Stamp.Server.csproj
@@ -49,13 +49,13 @@
 
   <ItemGroup>
     <Protobuf Include="../Protos/common.proto" Link="Protos\common.proto">
-      <SourceUrl>https://raw.githubusercontent.com/project-origin/registry/v1.3.1/src/Protos/common.proto</SourceUrl>
+      <SourceUrl>https://raw.githubusercontent.com/project-origin/registry/v2.0.0/protos/common.proto</SourceUrl>
     </Protobuf>
     <Protobuf Include="../Protos/registry.proto" Link="Protos\registry.proto">
-      <SourceUrl>https://raw.githubusercontent.com/project-origin/registry/v1.3.1/src/Protos/registry.proto</SourceUrl>
+      <SourceUrl>https://raw.githubusercontent.com/project-origin/registry/v2.0.0/protos/registry.proto</SourceUrl>
     </Protobuf>
     <Protobuf Include="../Protos/electricity.proto" Link="Protos\electricity.proto">
-      <SourceUrl>https://raw.githubusercontent.com/project-origin/registry/v1.3.1/src/Protos/electricity.proto</SourceUrl>
+      <SourceUrl>https://raw.githubusercontent.com/project-origin/verifier_electricity/v1.2.0/protos/electricity.proto</SourceUrl>
     </Protobuf>
   </ItemGroup>
 

--- a/src/ProjectOrigin.Stamp.Test/Extensions/IContainerExtensions.cs
+++ b/src/ProjectOrigin.Stamp.Test/Extensions/IContainerExtensions.cs
@@ -1,0 +1,63 @@
+using System.Net;
+using DotNet.Testcontainers.Configurations;
+using DotNet.Testcontainers.Containers;
+using Testcontainers.PostgreSql;
+
+namespace ProjectOrigin.Stamp.Test.Extensions;
+
+public static class IContainerExtensions
+{
+    public static async Task StartWithLoggingAsync(this IContainer container)
+    {
+        try
+        {
+            await container.StartAsync();
+        }
+        catch (Exception e)
+        {
+            var (stdout, stderr) = await container.GetLogsAsync();
+            throw new Exception($"Container logs:\nStdout: {stdout}\nStderr:{stderr}", e);
+        }
+
+    }
+
+    public static IWaitForContainerOS UntilGrpcEndpointIsReady(this IWaitForContainerOS container, ushort grpcPort, string path, Action<IWaitStrategy>? waitStrategyModifier = null)
+    {
+        // This is a workaround to check if a grpc endpoint is ready.
+        // GRPC uses http2 requests which are not supported as a WaitStrategy.
+        // However, the message 'An HTTP/1.x request was sent to an HTTP/2 only endpoint.' indicates that endpoint is actually ready.
+
+        // Default timeout is 1 minute
+        waitStrategyModifier ??= ws => ws.WithTimeout(TimeSpan.FromMinutes(1));
+
+        return container.UntilHttpRequestIsSucceeded(s =>
+                    s.ForPath(path)
+                        .ForPort(grpcPort)
+                        .ForStatusCode(HttpStatusCode.BadRequest)
+                        .ForResponseMessageMatching(async r =>
+                            {
+                                var content = await r.Content.ReadAsStringAsync();
+                                var isHttp2ServerReady = "An HTTP/1.x request was sent to an HTTP/2 only endpoint.".Equals(content);
+                                return isHttp2ServerReady;
+                            })
+                    , waitStrategyModifier
+        );
+    }
+
+    public static string GetLocalConnectionString(this PostgreSqlContainer container, string networkAlias)
+    {
+        var connectionProperties = new Dictionary<string, string>
+        {
+            { "Host", networkAlias },
+            {
+                "Port",
+                ((ushort)5432).ToString()
+            },
+            { "Database", "postgres" },
+            { "Username", "postgres" },
+            { "Password", "postgres" }
+        };
+
+        return string.Join(";", connectionProperties.Select((KeyValuePair<string, string> property) => string.Join("=", property.Key, property.Value)));
+    }
+}

--- a/src/ProjectOrigin.Stamp.Test/TestClassFixtures/RegistryFixture.cs
+++ b/src/ProjectOrigin.Stamp.Test/TestClassFixtures/RegistryFixture.cs
@@ -5,6 +5,8 @@ using DotNet.Testcontainers.Images;
 using DotNet.Testcontainers.Networks;
 using ProjectOrigin.HierarchicalDeterministicKeys;
 using ProjectOrigin.HierarchicalDeterministicKeys.Interfaces;
+using ProjectOrigin.Stamp.Test.Extensions;
+using Testcontainers.PostgreSql;
 using Testcontainers.RabbitMq;
 using Xunit;
 
@@ -12,62 +14,77 @@ namespace ProjectOrigin.Stamp.Test.TestClassFixtures;
 
 public class RegistryFixture : IAsyncLifetime
 {
-    private const string registryImage = "ghcr.io/project-origin/registry-server:1.3.0";
-    private const string electricityVerifierImage = "ghcr.io/project-origin/electricity-server:1.1.0";
+    private const string registryImage = "ghcr.io/project-origin/registry-server:2.0.0";
+    private const string electricityVerifierImage = "ghcr.io/project-origin/electricity-server:1.2.0";
     protected const int GrpcPort = 5000;
     private const int RabbitMqHttpPort = 15672;
     private const string registryName = "TestRegistry";
     private const string RegistryAlias = "registry-container";
     private const string VerifierAlias = "verifier-container";
+    private const string VerifierPostgresAlias = "verifier-postgres-container";
     private const string RabbitMqAlias = "rabbitmq-container";
 
     private readonly IContainer registryContainer;
     private readonly IContainer verifierContainer;
     private readonly Testcontainers.RabbitMq.RabbitMqContainer rabbitMqContainer;
+    private readonly PostgreSqlContainer registryPostgresContainer;
     protected readonly INetwork Network;
     private readonly IFutureDockerImage rabbitMqImage;
-
     public const string RegistryName = registryName;
     public IPrivateKey Dk1IssuerKey { get; init; }
     public IPrivateKey Dk2IssuerKey { get; init; }
     public string RegistryUrl => $"http://{registryContainer.Hostname}:{registryContainer.GetMappedPublicPort(GrpcPort)}";
     protected string RegistryContainerUrl => $"http://{registryContainer.IpAddress}:{GrpcPort}";
-
     public RegistryFixture()
     {
         Network = new NetworkBuilder()
             .WithName(Guid.NewGuid().ToString())
             .Build();
-
         rabbitMqImage = new ImageFromDockerfileBuilder()
             .WithDockerfileDirectory(CommonDirectoryPath.GetProjectDirectory(), string.Empty)
             .WithDockerfile("rabbitmq.dockerfile")
             .Build();
-
         rabbitMqContainer = new RabbitMqBuilder()
             .WithImage(rabbitMqImage)
             .WithNetwork(Network)
             .WithNetworkAliases(RabbitMqAlias)
             .WithPortBinding(RabbitMqHttpPort, true)
             .Build();
-
         Dk1IssuerKey = Algorithms.Ed25519.GenerateNewPrivateKey();
         Dk2IssuerKey = Algorithms.Ed25519.GenerateNewPrivateKey();
+
+        var configFile = Path.GetTempFileName() + ".yaml";
+        File.WriteAllText(configFile, $"""
+        registries:
+          {registryName}:
+            url: http://{RegistryAlias}:{GrpcPort}
+        areas:
+          DK1:
+            issuerKeys:
+              - publicKey: "{Convert.ToBase64String(Encoding.UTF8.GetBytes(Dk1IssuerKey.PublicKey.ExportPkixText()))}"
+          DK2:
+            issuerKeys:
+              - publicKey: "{Convert.ToBase64String(Encoding.UTF8.GetBytes(Dk2IssuerKey.PublicKey.ExportPkixText()))}"
+        """);
 
         verifierContainer = new ContainerBuilder()
                 .WithImage(electricityVerifierImage)
                 .WithNetwork(Network)
                 .WithNetworkAliases(VerifierAlias)
+                .WithResourceMapping(configFile, "/app/tmp/")
                 .WithPortBinding(GrpcPort, true)
                 .WithCommand("--serve")
-                .WithEnvironment("Issuers__DK1", Convert.ToBase64String(Encoding.UTF8.GetBytes(Dk1IssuerKey.PublicKey.ExportPkixText())))
-                .WithEnvironment("Issuers__DK2", Convert.ToBase64String(Encoding.UTF8.GetBytes(Dk2IssuerKey.PublicKey.ExportPkixText())))
-                .WithEnvironment($"Registries__{RegistryName}__Address", $"http://{RegistryAlias}:{GrpcPort}")
-                .WithWaitStrategy(
-                    Wait.ForUnixContainer()
-                        .UntilPortIsAvailable(GrpcPort)
-                    )
+                .WithEnvironment("Network__ConfigurationUri", "file:///app/tmp/" + Path.GetFileName(configFile))
+                .WithWaitStrategy(Wait.ForUnixContainer().UntilGrpcEndpointIsReady(GrpcPort, "/"))
+                // .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(GrpcPort, o => o.WithTimeout(TimeSpan.FromSeconds(10))))
                 .Build();
+
+        registryPostgresContainer = new PostgreSqlBuilder()
+            .WithImage("postgres:15")
+            .WithNetwork(Network)
+            .WithNetworkAliases(VerifierPostgresAlias)
+            .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(5432))
+            .Build();
 
         registryContainer = new ContainerBuilder()
             .WithImage(registryImage)
@@ -80,7 +97,6 @@ public class RegistryFixture : IAsyncLifetime
             .WithEnvironment("Verifiers__project_origin.electricity.v1", $"http://{VerifierAlias}:{GrpcPort}")
             .WithEnvironment("IMMUTABLELOG__TYPE", "log")
             .WithEnvironment("BlockFinalizer__Interval", "00:00:05")
-            .WithEnvironment("PERSISTANCE__TYPE", "in_memory")
             .WithEnvironment("cache__TYPE", "InMemory")
             .WithEnvironment("RabbitMq__Hostname", RabbitMqAlias)
             .WithEnvironment("RabbitMq__AmqpPort", RabbitMqBuilder.RabbitMqPort.ToString())
@@ -91,10 +107,8 @@ public class RegistryFixture : IAsyncLifetime
             .WithEnvironment("TransactionProcessor__Servers", "1")
             .WithEnvironment("TransactionProcessor__Threads", "5")
             .WithEnvironment("TransactionProcessor__Weight", "10")
-            .WithWaitStrategy(
-                Wait.ForUnixContainer()
-                    .UntilPortIsAvailable(GrpcPort)
-            )
+            .WithEnvironment("ConnectionStrings__Database", registryPostgresContainer.GetLocalConnectionString(VerifierPostgresAlias))
+            .WithWaitStrategy(Wait.ForUnixContainer().UntilGrpcEndpointIsReady(GrpcPort, "/"))
             .Build();
     }
 
@@ -102,14 +116,16 @@ public class RegistryFixture : IAsyncLifetime
     {
         await rabbitMqImage.CreateAsync();
         await Network.CreateAsync();
-        await rabbitMqContainer.StartAsync();
-        await verifierContainer.StartAsync();
-        await registryContainer.StartAsync();
+        await rabbitMqContainer.StartWithLoggingAsync();
+        await verifierContainer.StartWithLoggingAsync();
+        await registryPostgresContainer.StartWithLoggingAsync();
+        await registryContainer.StartWithLoggingAsync();
     }
 
     public virtual async Task DisposeAsync()
     {
         await registryContainer.StopAsync();
+        await registryPostgresContainer.StopAsync();
         await rabbitMqContainer.StopAsync();
         await verifierContainer.StopAsync();
         await Network.DisposeAsync();

--- a/src/Protos/electricity.proto
+++ b/src/Protos/electricity.proto
@@ -48,6 +48,14 @@ message ClaimedEvent {
     project_origin.common.v1.Uuid allocation_id = 2;
 }
 
+message WithdrawnEvent {
+
+}
+
+message UnclaimedEvent {
+    project_origin.common.v1.Uuid allocation_id = 1;
+}
+
 enum GranularCertificateType {
     INVALID = 0;
     CONSUMPTION = 1;


### PR DESCRIPTION
After the upgrade of registry and verifier_electricity, I experienced several issues

Here are the changes:
- I used WithResourceMapping to add a file to the test container (This was to solve permission errors)
- I had to change to a different "WaitStrategy", because the two test containers where suddenly "stalling" when waiting for the GRPC port (this was a result of smaller base image being used)? I have added an Extension method to check if the GRPC port is open
- The registry seems to no longer support an in-memory database. I have added a PostgresContainer and use the connectionString from this