### PR TITLE
Split retry policies to endpoint and consumer and filter out R-RETRY logging stamement

### DIFF
--- a/src/ProjectOrigin.Stamp.Server/Extensions/IConfigurationExtensions.cs
+++ b/src/ProjectOrigin.Stamp.Server/Extensions/IConfigurationExtensions.cs
@@ -65,6 +65,7 @@ public static class IConfigurationExtensions
         var loggerConfiguration = new LoggerConfiguration()
             .Filter.ByExcluding("RequestPath like '/health%'")
             .Filter.ByExcluding("RequestPath like '/metrics%'")
+            .Filter.ByExcluding("SourceContext = 'MassTransit.ReceiveTransport' and MessageTemplate = 'R-RETRY {InputAddress} {MessageId} {MessageType}'")
             .Enrich.WithSpan();
 
         var logOutputFormat = configuration.GetValue<string>("LogOutputFormat");

--- a/src/ProjectOrigin.Stamp.Server/Options/RetryOptions.cs
+++ b/src/ProjectOrigin.Stamp.Server/Options/RetryOptions.cs
@@ -1,9 +1,10 @@
 using System.ComponentModel.DataAnnotations;
 
 namespace ProjectOrigin.Stamp.Server.Options;
+
 public class RetryOptions
 {
-    public const string Retry = nameof(Retry);
+    public const string Prefix = "Retry";
 
     [Required]
     public int DefaultFirstLevelRetryCount { get; set; }

--- a/src/ProjectOrigin.Stamp.Server/Startup.cs
+++ b/src/ProjectOrigin.Stamp.Server/Startup.cs
@@ -74,7 +74,7 @@ public class Startup
             .ValidateOnStart();
 
         services.AddOptions<RetryOptions>()
-            .BindConfiguration(RetryOptions.Retry)
+            .BindConfiguration(RetryOptions.Prefix)
             .ValidateDataAnnotations()
             .ValidateOnStart();
 


### PR DESCRIPTION
- Split retry policies to endpoint and consumer
  - Before the last retry policy "won" (it overwrote the first one)
- Filter out R-RETRY logging stamement
  - The R-RETRY warning is logged every time a new retry occurs.

Preview env - no R-RETRY logs:
https://grafana.masstransitretrylog.p.acorn-dev.dk/d/liz0yRCZz/loki-dashboard-quick-search?orgId=1&from=now-24h&to=now&timezone=browser&var-DS_PROMETHEUS=thanos&var-DS_LOKI=loki&var-namespace=eo&var-pod=$__all&var-container=$__all&var-job=$__all&var-app=$__all&var-stream=$__all&var-level=$__all&var-search=R-RETRY